### PR TITLE
Prep for interoperability; add supermolecular option

### DIFF
--- a/sparcle_qc/df_make_psi4.py
+++ b/sparcle_qc/df_make_psi4.py
@@ -996,6 +996,11 @@ def dump_pkl():
         out.write(json.dumps(results))
 '''
 
+def write_file(software, qm_lig, c_QM, qm_pro, mm_env, PSI4_FILE_PATH:str, c_ligand:str, method:str, basis_set:str, do_fsapt: bool = None):
+    if software.lower() == 'psi4':
+        write_psi4_file(qm_lig, c_QM, qm_pro, mm_env, PSI4_FILE_PATH, c_ligand, method, basis_set, do_fsapt)
+
+
 def write_input(inputfile, psi4file):
     """
     Writes the Sparcle-QC input file to the top of the psi4file


### PR DESCRIPTION
## Description
Preps for easy interoperability and allows for supermolecular calculations.

Code works up until check_qm_file. It will not check the psi4 files if we use something other than SAPT. I will fix this function once I implement Q-Chem and NWChem. check_qm_file will need to work for all software, SAPT and non-SAPT.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] new required keyword added: 'software'; checks that software is compatible
  - [x] allows for non-SAPT methods. If not SAPT, creates 3 input files: lig, prot, and cx
  - [x] makes software a keyword argument to the file writing function. will allow for easy addition of nwchem and q-chem templates
  - [x] separates file writing from QM and MM coordinate generation

## Status
- [x] Ready to go