### PR TITLE
Charge scheme testing

### DIFF
--- a/sparcle_qc/df_make_psi4.py
+++ b/sparcle_qc/df_make_psi4.py
@@ -237,12 +237,13 @@ def SEE(MOL2_PATH:str, CAPPED_PDB_PATH: str, with_HL: Dict[str,List[int]], num_b
 
     Returns
     -------
-    MM_for_array: List[str]
+    mm_env: List[str]
         list of the charges along with xyz coords
     """
     seeatoms = SEE_atoms(num_bonds_broken, with_HL) #get atoms from indexing
     seelines = atoms_to_pdb_lines(CAPPED_PDB_PATH, seeatoms) #get PDB lines from atoms list
     seexyz = pdb_to_xyz(seelines) # get XYZ lines from PDB lines
+    MM_for_array = []
     mm_env = MM_xyz_to_charge_array(seexyz, None, MOL2_PATH, MM_for_array) # get charges from XYZ lines
     return mm_env
 
@@ -541,7 +542,7 @@ def Z3_atoms_zero(num_bonds_broken:int, with_HL:Dict[str,List[int]]) -> List[int
             MM_atoms += with_HL[f'M3_{bond}']
     return MM_atoms
 
-def Z3(with_HL:Dict[str,List[int]], num_bonds_broken:int) -> List[str]:
+def Z3(df:pd.DataFrame,with_HL:Dict[str,List[int]], num_bonds_broken:int) -> List[str]:
     """
     returns external charge array, zeroes the M1 and M2 and M3 atoms
 
@@ -891,7 +892,7 @@ def make_regions(charge_method:str) -> None:
     elif charge_method == 'DZ2':
           mm_env = DZn(2, df, with_HL, num_bonds_broken)
     elif charge_method == 'Z3':
-          mm_env = Z3(with_HL, num_bonds_broken)
+          mm_env = Z3(df, with_HL, num_bonds_broken)
     elif charge_method == 'DZ3':
           mm_env = DZn(3, df, with_HL, num_bonds_broken)
     elif charge_method == 'BRC':

--- a/sparcle_qc/tests/test_sparcle_qc.py
+++ b/sparcle_qc/tests/test_sparcle_qc.py
@@ -317,3 +317,147 @@ def test_run_dz2():
     output_dictionary= sparcle_qc.run(user_options = inputs)
     true_dictionary = (586, 4290, 4.0, 2.0)
     assert output_dictionary == true_dictionary
+def test_run_z1():
+    inputs = {
+    'input_filename': 'test13.in',
+    'pdb_file': '3QXP_templated_amber.pdb',
+    'cutoff': 6,
+    'seed': 'ligand',
+    'charge_scheme': 'Z1',
+    'ligand_charge': 0,
+    'method': 'hf',
+    'basis_set': 'aug-cc-pv(D+d)z',
+    'amber_ff': 'ff19SB',
+    'env_path': '/theoryfs2/ds/ipberry/miniconda3/envs/emb_sapt/',
+    'water_model': 'opc' ,
+    'o_charge': 0,
+    'h_charge': 0.6791,
+    'ep_charge': -1.3582,
+    'software': 'psi4',
+    'mem': '100 GB',
+    'nthreads': 16,
+    }
+    
+    output_dictionary= sparcle_qc.run(user_options = inputs)
+    true_dictionary = {'Complex': [721, 4207, 2.0, -0.3], 'Ligand': [41, 0, 0.0, 0.0], 'Protein': [680, 4207, 2.0, -0.3]}
+    assert output_dictionary == true_dictionary
+def test_run_z2():
+    inputs = {
+    'input_filename': 'test14.in',
+    'pdb_file': '3QXP_templated_amber.pdb',
+    'cutoff': 6,
+    'seed': 'ligand',
+    'charge_scheme': 'Z2',
+    'ligand_charge': 0,
+    'method': 'hf',
+    'basis_set': 'aug-cc-pv(D+d)z',
+    'amber_ff': 'ff19SB',
+    'env_path': '/theoryfs2/ds/ipberry/miniconda3/envs/emb_sapt/',
+    'water_model': 'opc' ,
+    'o_charge': 0,
+    'h_charge': 0.6791,
+    'ep_charge': -1.3582,
+    'software': 'psi4',
+    'mem': '100 GB',
+    'nthreads': 16,
+    }
+    
+    output_dictionary= sparcle_qc.run(user_options = inputs)
+    true_dictionary = {'Complex': [721, 4207, 2.0, 6.97], 'Ligand': [41, 0, 0.0, 0.0], 'Protein': [680, 4207, 2.0, 6.97]}
+    assert output_dictionary == true_dictionary
+def test_run_z3():
+    inputs = {
+    'input_filename': 'test15.in',
+    'pdb_file': '3QXP_templated_amber.pdb',
+    'cutoff': 6,
+    'seed': 'ligand',
+    'charge_scheme': 'Z3',
+    'ligand_charge': 0,
+    'method': 'hf',
+    'basis_set': 'aug-cc-pv(D+d)z',
+    'amber_ff': 'ff19SB',
+    'env_path': '/theoryfs2/ds/ipberry/miniconda3/envs/emb_sapt/',
+    'water_model': 'opc' ,
+    'o_charge': 0,
+    'h_charge': 0.6791,
+    'ep_charge': -1.3582,
+    'software': 'psi4',
+    'mem': '100 GB',
+    'nthreads': 16,
+    }
+    
+    output_dictionary= sparcle_qc.run(user_options = inputs)
+    true_dictionary = {'Complex': [721, 4207, 2.0, 4.97], 'Ligand': [41, 0, 0.0, 0.0], 'Protein': [680, 4207, 2.0, 4.97]} 
+    assert output_dictionary == true_dictionary
+def test_run_brcd():
+    inputs = {
+    'input_filename': 'test16.in',
+    'pdb_file': '3QXP_templated_amber.pdb',
+    'cutoff': 6,
+    'seed': 'ligand',
+    'charge_scheme': 'BRCD',
+    'ligand_charge': 0,
+    'method': 'hf',
+    'basis_set': 'aug-cc-pv(D+d)z',
+    'amber_ff': 'ff19SB',
+    'env_path': '/theoryfs2/ds/ipberry/miniconda3/envs/emb_sapt/',
+    'water_model': 'opc' ,
+    'o_charge': 0,
+    'h_charge': 0.6791,
+    'ep_charge': -1.3582,
+    'software': 'psi4',
+    'mem': '100 GB',
+    'nthreads': 16,
+    }
+    
+    output_dictionary= sparcle_qc.run(user_options = inputs)
+    true_dictionary = {'Complex': [721, 4225, 2.0, 3.0], 'Ligand': [41, 0, 0.0, 0.0], 'Protein': [680, 4225, 2.0, 3.0]}
+    assert output_dictionary == true_dictionary
+def test_run_brc2():
+    inputs = {
+    'input_filename': 'test17.in',
+    'pdb_file': '3QXP_templated_amber.pdb',
+    'cutoff': 6,
+    'seed': 'ligand',
+    'charge_scheme': 'BRC2',
+    'ligand_charge': 0,
+    'method': 'hf',
+    'basis_set': 'aug-cc-pv(D+d)z',
+    'amber_ff': 'ff19SB',
+    'env_path': '/theoryfs2/ds/ipberry/miniconda3/envs/emb_sapt/',
+    'water_model': 'opc' ,
+    'o_charge': 0,
+    'h_charge': 0.6791,
+    'ep_charge': -1.3582,
+    'software': 'psi4',
+    'mem': '100 GB',
+    'nthreads': 16,
+    }
+    
+    output_dictionary= sparcle_qc.run(user_options = inputs)
+    true_dictionary = {'Complex': [721, 4195, 2.0, 3.0], 'Ligand': [41, 0, 0.0, 0.0], 'Protein': [680, 4195, 2.0, 3.0]}
+    assert output_dictionary == true_dictionary
+def test_run_see():
+    inputs = {
+    'input_filename': 'test18.in',
+    'pdb_file': '3QXP_templated_amber.pdb',
+    'cutoff': 6,
+    'seed': 'ligand',
+    'charge_scheme': 'SEE',
+    'ligand_charge': 0,
+    'method': 'hf',
+    'basis_set': 'aug-cc-pv(D+d)z',
+    'amber_ff': 'ff19SB',
+    'env_path': '/theoryfs2/ds/ipberry/miniconda3/envs/emb_sapt/',
+    'water_model': 'opc' ,
+    'o_charge': 0,
+    'h_charge': 0.6791,
+    'ep_charge': -1.3582,
+    'software': 'psi4',
+    'mem': '100 GB',
+    'nthreads': 16,
+    }
+    
+    output_dictionary= sparcle_qc.run(user_options = inputs)
+    true_dictionary = {'Complex': [721, 78, 2.0, -1.81], 'Ligand': [41, 0, 0.0, 0.0], 'Protein': [680, 78, 2.0, -1.81]}
+    assert output_dictionary == true_dictionary


### PR DESCRIPTION
## Description
Adding pytests for all the different charge schemes. These still create temp directories that we still need to clean up. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] adds pytest for different charge schemes
  - [x]  cleans up small bugs in df_make_psi4.py that were found during testing

## Status
- [x] Ready to go

## Comments
I think we are going to have issues with absolute paths since we have implemented everything with relative paths and therefore if people try to use sparcle outside their working directory with all of their files i think issues may arise. this is something we can consider when we go in and fix up all the file and functions names 