### PR TITLE
add option to include other amber ffs

### DIFF
--- a/sparcle_qc/amber_prep.py
+++ b/sparcle_qc/amber_prep.py
@@ -192,7 +192,7 @@ def write_cpptraj_skip_autocap(pdb_file: str) -> None:
         f.write(f'loadcrd {pdb_file} name tmp1\n')
         f.write(f'prepareforleap crdset tmp1 name tmp2 pdbout cx_autocap.pdb nosugar\n')
 
-def write_tleap(forcefield: str, water_model: str) -> None:
+def write_tleap(forcefield: str, water_model: str, other_ffs: list) -> None:
     """
     Writes a tleap input file that loads the given forcefield and water model
 
@@ -202,6 +202,8 @@ def write_tleap(forcefield: str, water_model: str) -> None:
         name of amber forcefield (ex. ff19SB)
     water_model: str
         name of the desired water model (ex. OPC)
+    other_ffs: list
+        list of names of non-water, non-protein model (ex. ['leaprc.DNA.OL15', 'leaprc.gaff2'])
 
     Returns
     -------
@@ -210,6 +212,8 @@ def write_tleap(forcefield: str, water_model: str) -> None:
     with open('tleap.in', 'w') as f:
         f.write(f'source leaprc.protein.{forcefield}\n')
         f.write(f'source leaprc.water.{water_model}\n')
+        for ff in other_ffs:
+            f.write(f'source {ff}\n')
         f.write(f'mol = loadPdb "prot_autocap_fixed.pdb"\n')
         f.write(f'savemol2 mol prot_autocap_fixed.mol2 1\n')
         f.write('quit')

--- a/sparcle_qc/sparcle_qc.py
+++ b/sparcle_qc/sparcle_qc.py
@@ -307,6 +307,15 @@ def input_parser(filename:str) -> Dict:
     if keywords['software'] == 'nwchem' and 'sapt' in keywords['method']:
         print('Error: SAPT is not available in NWChem. Choose a different method.')
         sys.exit()
+    if 'other_amber_ff' in keywords.keys():
+        try:
+            ast.literal_eval(keywords['other_amber_ff'])
+        except:
+            print("Error: other_amber_ff is not a list of strings")
+            sys.exit()
+        keywords['other_amber_ff'] = ast.literal_eval(keywords['other_amber_ff'])
+    else:
+        keywords['other_amber_ff'] = []
     print(f"\u2728Sparcle-QC is sparkling\u2728\nBeginning file preparation for an embedded QM calculation of {keywords['pdb_file']} ")
     
     return keywords
@@ -425,7 +434,7 @@ def run(input_file= None, user_options = None) -> None:
             seed, seed_coords = convert_atom_id(keywords['seed'], keywords['seed_file'])
         #if forcefield is amber, writing and running tleap to create mol2
         if 'amber_ff' in keywords:
-            write_tleap(keywords['amber_ff'], keywords['water_model'])
+            write_tleap(keywords['amber_ff'], keywords['water_model'], keywords['other_amber_ff'])
             result = subprocess.run(['tleap -f tleap.in'], text = True, shell = True, capture_output = True)
             output.write('----------------------------------------------------------------------------------------------------\n')
             output.write('tleap'.center(100)+'\n')


### PR DESCRIPTION
## Description
This PR adds the ability to include non protein and water amber ffs in the tleap. Users can optionally add the keyword 'other_amber_ff' with a value that is a list of strings of their desired additional forcefields. (ex other_amber_ff: 'leaprc.DNA.OL15', 'leaprc.gaff2')

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] adds option and checks that value is a list of strings
  - [x] incorporates writing of additional ffs to tleap


## Status
- [x] Ready to go