### PR TITLE
removing env_path

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -58,7 +58,6 @@ or by passing a dictionary of inputs:
     'method': 'hf',
     'basis_set': 'aug-cc-pv(D+d)z',
     'amber_ff': 'ff19SB',
-    'env_path': f'path/to/conda/env/sparcle_qc',
     'software': 'psi4',
     }
 

--- a/docs/options/forcefields.csv
+++ b/docs/options/forcefields.csv
@@ -1,9 +1,9 @@
-Keyword,Description,Option Type,Required if using
-amber_ff,Amber forcefield for point charges (ex. ff19SB),string,Amber
-charmm_rtf,Path to CHARMM .rtf file of desired CHARM force field,string,CHARMM
-charmm_prm,Path to CHARMM .prm file of desired CHARMM force field,string,CHARMM
-water_model,Desired water model (ex. TIP3P or OPC),string,Amber or CHARMM
-o_charge,"Custom oxygen charge for water, optional",float,
-h_charge,"Custom hydrogen charge for water, optional",float,
-ep_charge,"Custom extra point charge for water, optional. If extra point charge is given, set water_model to a four-point water model for generation of extra point charge coordinates.",float,
-other_amber_ff,"List of other (non-protein, non-water) Amber FFs to be used. (ex. 'leaprc.DNA.OL15', 'leaprc.gaff2')",list,Amber
+"Keyword","Description","Option Type","Required if using"
+"amber_ff","Amber forcefield for point charges (ex. ff19SB) :raw-html:`<br>` :sub:`Note: We use Parm19.dat for the C-C and C-H bond lengths because they are consistent between ff19, ff14, and ff99. For the most reliable results use SparcleQC with one of these Amber forcefields.`","string","Amber"
+"charmm_rtf","Path to CHARMM .rtf file of desired CHARM force field","string","CHARMM"
+"charmm_prm","Path to CHARMM .prm file of desired CHARMM force field","string","CHARMM"
+"water_model","Desired water model (ex. TIP3P or OPC)","string","Amber or CHARMM"
+"o_charge","Custom oxygen charge for water, optional","float"
+"h_charge","Custom hydrogen charge for water, optional","float"
+"ep_charge","Custom extra point charge for water, optional. If extra point charge is given, set water_model to a four-point water model for generation of extra point charge coordinates.","float"
+"other_amber_ff","List of other (non-protein, non-water) Amber FFs to be used. (ex. 'leaprc.DNA.OL15', 'leaprc.gaff2')","list","Amber"

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -246,6 +246,9 @@ Options
     .. csv-table:: 
         :file: options/required.csv
 
+.. role:: raw-html(raw)
+    :format: html
+
 .. dropdown:: Force Fields
 
     .. csv-table:: 


### PR DESCRIPTION
## Description
I was going to wait to put this in a later PR so that it wouldn't be just one line. But I don't want to forget over break that this fix is still hanging out. 

Removing the env_path keyword from the example on the install page. Also added a note in the forcefields csv about our usage of parm19.dat for the bond lengths and that our package will work best with ff19, ff14, or ff99. 